### PR TITLE
Rename extension traits as per rust-lang/rfcs#445

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,12 +56,12 @@ pub fn unreachable<T = ()>(_: Void) -> T {
 }
 
 /// Extensions to `Result<T, Void>`
-pub trait VoidExtensions<T>: Sized {
+pub trait ResultVoidExt<T>: Sized {
     /// Get the value out of a wrapper.
     fn void_unwrap(self) -> T;
 }
 
-impl<T> VoidExtensions<T> for Result<T, Void> {
+impl<T> ResultVoidExt<T> for Result<T, Void> {
     /// Get the value out of an always-ok Result.
     ///
     /// Never panics, since it is statically known to be Ok.
@@ -75,12 +75,12 @@ impl<T> VoidExtensions<T> for Result<T, Void> {
 }
 
 /// Extensions to `Result<Void, E>`
-pub trait ErrVoidExtensions<E>: Sized {
+pub trait ResultVoidErrExt<E>: Sized {
     /// Get the error out of a wrapper.
     fn void_unwrap_err(self) -> E;
 }
 
-impl<E> ErrVoidExtensions<E> for Result<Void, E> {
+impl<E> ResultVoidErrExt<E> for Result<Void, E> {
     /// Get the error out of an always-err Result.
     ///
     /// Never panics, since it is statically known to be Err.


### PR DESCRIPTION
Quoth [RFC 445](https://github.com/rust-lang/rfcs/blob/master/text/0445-extension-trait-conventions.md#the-convention):

> For true extension traits, there should be a clear type or trait that they are extending. The extension trait should be called `FooExt` where `Foo` is that type or trait.
> 
> In some cases, the extension trait only applies conditionally. For example, `AdditiveIterator` is an extension trait currently in std that applies to iterators over numeric types. These extension traits should follow a similar convention, putting together the type/trait name and the qualifications, together with the Ext suffix: `IteratorAddExt`.

This patch renames the extension traits to match this convention.
