### PR TITLE
Fix imports for rust 1.0.0 and rust 1.6.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,13 @@
 //! extra functionality to `Result<T, Void>` and `Result<Void, E>`.
 //!
 
-#[cfg(feature = "std")]
-extern crate core;
+#[cfg(not(feature = "std"))]
 use core::{fmt, cmp};
 
 #[cfg(feature = "std")]
 use std::error;
+#[cfg(feature = "std")]
+use std::{fmt, cmp};
 
 /// The empty type for cases which can't occur.
 #[derive(Copy)]


### PR DESCRIPTION
This PR makes `void` usable with stable versions up to 1.6.0 of the rust compiler.

In my tests libcore is automatically imported by the compiler when `no_std` is set.
