### PR TITLE
fix/test for older versions of rustc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 language: rust
 sudo: false
 
+rust:
+    - 1.0.0
+    - stable
+    - beta
+    - nightly
+
 script:
     - cargo build
     - cargo test
+    - if [ "$TRAVIS_RUST_VERSION" != "1.0.0" ]; then cargo test --no-default-features; fi
     - cargo bench --no-run
     - cargo doc
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,18 @@
 //! extra functionality to `Result<T, Void>` and `Result<Void, E>`.
 //!
 
-#[cfg(feature = "std")]
-extern crate core;
-use core::{fmt, cmp};
+#[cfg(not(feature = "std"))]
+mod coreprovider {
+    extern crate core;
+    pub use core::{fmt, cmp};
+}
 
 #[cfg(feature = "std")]
-use std::error;
+mod coreprovider {
+    pub use std::{fmt, cmp, error};
+}
+
+use coreprovider::*;
 
 /// The empty type for cases which can't occur.
 #[derive(Copy)]


### PR DESCRIPTION
Support for rust <1.6 appears to have regressed with the changes
introduced to support `no_std` in commit
86196aa4a7d6911455d236614d55331dc1e577ff.  This change properly
boxes off the `no_std` functionality and adds testing against
1.0.0 to ensure things will work on older versions.

Fixes #10

Signed-off-by: Paul Osborne osbpau@gmail.com
