### PR TITLE
Implement `Eq` and `Ord`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ mod coreprovider {
 use coreprovider::*;
 
 /// The empty type for cases which can't occur.
-#[derive(Copy)]
+#[derive(Copy, Eq, Ord)]
 pub enum Void { }
 
 impl Clone for Void {


### PR DESCRIPTION
I think there are no reasons not implementing `Eq` and `Ord` for `Void`.