### PR TITLE
Added `infallible ` feature to alias `void::Void` to `core::convert::Infallible`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 sudo: false
 
 rust:
-    - 1.0.0
+    - 1.34.0
     - stable
     - beta
     - nightly
@@ -10,7 +10,9 @@ rust:
 script:
     - cargo build
     - cargo test
-    - if [ "$TRAVIS_RUST_VERSION" != "1.0.0" ]; then cargo test --no-default-features; fi
+    - cargo test --no-default-features
+    - cargo test --features=infallible
+    - cargo test --no-default-features --features=infallible
     - cargo bench --no-run
     - cargo doc
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,11 @@ repository = "https://github.com/reem/rust-void.git"
 description = "The uninhabited void type for use in statically impossible cases."
 readme = "README.md"
 license = "MIT / Apache-2.0"
+edition = "2018"
 
 [features]
+std = []
+infallible = []
 
 default = ["std"]
-std = []
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,62 +10,61 @@
 //! This crate also comes ready with several extension traits for Result that add
 //! extra functionality to `Result<T, Void>` and `Result<Void, E>`.
 //!
+//! This can be aliased to core::convert::Infallible using the crates `infallible` feature.
+//!
 
-#[cfg(not(feature = "std"))]
-mod coreprovider {
-    extern crate core;
-    pub use core::{fmt, cmp};
-}
+/// The empty type for cases which can't occur (aliased to core::convert::Infallible)
+#[cfg(feature = "infallible")]
+pub type Void = core::convert::Infallible;
 
-#[cfg(feature = "std")]
-mod coreprovider {
-    pub use std::{fmt, cmp, error};
-}
+#[cfg(not(feature = "infallible"))]
+pub use void::Void;
 
-use coreprovider::*;
+#[cfg(not(feature = "infallible"))]
+mod void {
+    /// The empty type for cases which can't occur.
+    #[derive(Copy)]
+    pub enum Void { }
 
-/// The empty type for cases which can't occur.
-#[derive(Copy)]
-pub enum Void { }
-
-impl Clone for Void {
-    fn clone(&self) -> Void {
-        unreachable(*self)
-    }
-}
-
-impl fmt::Debug for Void {
-    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
-        unreachable(*self)
-    }
-}
-
-impl fmt::Display for Void {
-    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
-        unreachable(*self)
-    }
-}
-
-impl<T> cmp::PartialEq<T> for Void {
-    fn eq(&self, _: &T) -> bool {
-        unreachable(*self)
-    }
-}
-
-impl<T> cmp::PartialOrd<T> for Void {
-    fn partial_cmp(&self, _: &T) -> Option<cmp::Ordering> {
-        unreachable(*self)
-    }
-}
-
-#[cfg(feature = "std")]
-impl error::Error for Void {
-    fn description(&self) -> &str {
-        unreachable(*self)
+    impl Clone for Void {
+        fn clone(&self) -> Void {
+            super::unreachable(*self)
+        }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
-        unreachable(*self)
+    impl core::fmt::Debug for Void {
+        fn fmt(&self, _: &mut core::fmt::Formatter) -> core::fmt::Result {
+            super::unreachable(*self)
+        }
+    }
+
+    impl core::fmt::Display for Void {
+        fn fmt(&self, _: &mut core::fmt::Formatter) -> core::fmt::Result {
+            super::unreachable(*self)
+        }
+    }
+
+    impl<T> core::cmp::PartialEq<T> for Void {
+        fn eq(&self, _: &T) -> bool {
+            super::unreachable(*self)
+        }
+    }
+
+    impl<T> core::cmp::PartialOrd<T> for Void {
+        fn partial_cmp(&self, _: &T) -> Option<core::cmp::Ordering> {
+            super::unreachable(*self)
+        }
+    }
+
+    #[cfg(feature = "std")]
+    impl std::error::Error for Void {
+        fn description(&self) -> &str {
+            super::unreachable(*self)
+        }
+
+        fn cause(&self) -> Option<&(dyn std::error::Error)> {
+            super::unreachable(*self)
+        }
     }
 }
 


### PR DESCRIPTION
Provides a mechanism for interoperability with code using `core::convert::Infallible` while migrating components from `void::Void`.

Resolves #13, this is breaking due to a required MSRV bump to `1.34.0` for the `dyn` keyword and `std::error::Error` types.