### PR TITLE
Fix Rust 2015 error and Run cargo fmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "void"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Jonathan Reem <jonathan.reem@gmail.com>"]
 repository = "https://github.com/reem/rust-void.git"
 description = "The uninhabited void type for use in statically impossible cases."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ impl error::Error for Void {
         unreachable(*self)
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         unreachable(*self)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,19 +14,19 @@
 #[cfg(not(feature = "std"))]
 mod coreprovider {
     extern crate core;
-    pub use core::{fmt, cmp};
+    pub use core::{cmp, fmt};
 }
 
 #[cfg(feature = "std")]
 mod coreprovider {
-    pub use std::{fmt, cmp, error};
+    pub use std::{cmp, error, fmt};
 }
 
 use coreprovider::*;
 
 /// The empty type for cases which can't occur.
 #[derive(Copy)]
-pub enum Void { }
+pub enum Void {}
 
 impl Clone for Void {
     fn clone(&self) -> Void {
@@ -95,7 +95,7 @@ impl<T> ResultVoidExt<T> for Result<T, Void> {
     fn void_unwrap(self) -> T {
         match self {
             Ok(val) => val,
-            Err(e) => unreachable(e)
+            Err(e) => unreachable(e),
         }
     }
 }
@@ -114,8 +114,7 @@ impl<E> ResultVoidErrExt<E> for Result<Void, E> {
     fn void_unwrap_err(self) -> E {
         match self {
             Ok(v) => unreachable(v),
-            Err(e) => e
+            Err(e) => e,
         }
     }
 }
-


### PR DESCRIPTION
~~This PR adds `Send` and `Sync` to `Void`. This PR arose from my work in `rs-ipfs` where a trait added a bound of `Send` that broke the downstream uses.~~ I apologize and after more digging into `std::convert::Infalliable`, I realized that Send + Sync was auto implemented for `Void` as well. I'll have to do more digging into my type errors.


This PR also includes a fix for the Rust 2015 error in the source. With also a `cargo fmt` formatting commit.