### PR TITLE
Impl `AsRef` and `AsMut` for `Void`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,18 @@ impl<T> cmp::PartialOrd<T> for Void {
     }
 }
 
+impl<T> AsRef<T> for Void {
+    fn as_ref(&self) -> &T {
+        unreachable(*self)
+    }
+}
+
+impl<T> AsMut<T> for Void {
+    fn as_mut(&mut self) -> &mut T {
+        unreachable(*self)
+    }
+}
+
 #[cfg(feature = "std")]
 impl error::Error for Void {
     fn description(&self) -> &str {


### PR DESCRIPTION
This allows `Void` to be used in more places where these trait bounds are required.

Motivated by https://github.com/libp2p/rust-libp2p/pull/3746#discussion_r1179959685.